### PR TITLE
fix(render): add server Node app and Render config

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,3 @@
+NODE_ENV=development
+PORT=3000
+ALLOWED_ORIGINS=http://localhost:5173

--- a/server/server.js
+++ b/server/server.js
@@ -31,5 +31,9 @@ const server = app.listen(port, host, () => {
 const wss = new WebSocketServer({ server });
 
 wss.on('connection', (ws) => {
+  console.log('ws connect');
   ws.send('hello');
+  ws.on('close', () => {
+    console.log('ws disconnect');
+  });
 });


### PR DESCRIPTION
## Summary
- add Express/WebSocket server with CORS and connection logging
- provide sample environment variables for server
- render.yaml configures server and client deploys

## Testing
- `node server/server.js & SERVER_PID=$!; sleep 1; curl -s http://localhost:3000/health; kill $SERVER_PID`
- `cd server && npm test` *(fails: Missing script: "test")*
- `cd client && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3382ef41c8328a36dce0f760f8c66