### PR TITLE
feat: add landing screen and aircraft selection

### DIFF
--- a/client/src/aircraft/models.ts
+++ b/client/src/aircraft/models.ts
@@ -1,0 +1,54 @@
+import * as THREE from 'three';
+
+const darkMat = new THREE.MeshStandardMaterial({ color: 0x444444, flatShading: true });
+const lightMat = new THREE.MeshStandardMaterial({ color: 0x777777, flatShading: true });
+const emissiveMat = new THREE.MeshBasicMaterial({ color: 0x00ffff });
+
+export function buildRaptorLike(material: THREE.Material = darkMat): THREE.Group {
+  const g = new THREE.Group();
+  const body = new THREE.Mesh(new THREE.BoxGeometry(0.8, 0.3, 5), material);
+  g.add(body);
+  const wing = new THREE.Mesh(new THREE.BoxGeometry(4, 0.05, 2.2), lightMat);
+  wing.position.set(0, -0.1, 0);
+  g.add(wing);
+  const tailL = new THREE.Mesh(new THREE.BoxGeometry(0.3, 1, 0.8), lightMat);
+  tailL.position.set(-0.6, 0.5, -2.2);
+  tailL.rotation.set(0, 0, THREE.MathUtils.degToRad(25));
+  g.add(tailL);
+  const tailR = tailL.clone();
+  tailR.position.x = 0.6;
+  tailR.rotation.z = THREE.MathUtils.degToRad(-25);
+  g.add(tailR);
+  const navL = new THREE.Mesh(new THREE.SphereGeometry(0.05), emissiveMat);
+  navL.position.set(-2, 0, 0);
+  const navR = navL.clone();
+  navR.position.x = 2;
+  g.add(navL, navR);
+  return g;
+}
+
+export function buildDragonLike(material: THREE.Material = darkMat): THREE.Group {
+  const g = new THREE.Group();
+  const body = new THREE.Mesh(new THREE.BoxGeometry(0.7, 0.3, 5.5), material);
+  g.add(body);
+  const wing = new THREE.Mesh(new THREE.BoxGeometry(3.6, 0.05, 2.4), lightMat);
+  wing.position.set(0, -0.1, -0.5);
+  g.add(wing);
+  const canard = new THREE.Mesh(new THREE.BoxGeometry(1.2, 0.05, 0.8), lightMat);
+  canard.position.set(0, 0.1, 1.2);
+  g.add(canard);
+  const tailL = new THREE.Mesh(new THREE.BoxGeometry(0.3, 1.1, 0.9), lightMat);
+  tailL.position.set(-0.6, 0.5, -2.5);
+  tailL.rotation.set(0, 0, THREE.MathUtils.degToRad(25));
+  const tailR = tailL.clone();
+  tailR.position.x = 0.6;
+  tailR.rotation.z = THREE.MathUtils.degToRad(-25);
+  g.add(tailL, tailR);
+  const navL = new THREE.Mesh(new THREE.SphereGeometry(0.05), emissiveMat);
+  navL.position.set(-1.8, 0, -0.3);
+  const navR = navL.clone();
+  navR.position.x = 1.8;
+  g.add(navL, navR);
+  return g;
+}
+

--- a/client/src/cam/chase.ts
+++ b/client/src/cam/chase.ts
@@ -1,0 +1,37 @@
+import * as THREE from 'three';
+
+/**
+ * Simple spring-damped chase camera.
+ */
+export class ChaseCamera {
+  private target: THREE.Object3D;
+  private cam: THREE.PerspectiveCamera;
+  private offset = new THREE.Vector3(0, 3.5, -12);
+  private current = new THREE.Vector3();
+  private look = new THREE.Vector3();
+  private yaw = 0;
+  private pitch = 0;
+
+  constructor(cam: THREE.PerspectiveCamera, target: THREE.Object3D) {
+    this.cam = cam;
+    this.target = target;
+    this.current.copy(target.position).add(this.offset);
+  }
+
+  update(dt: number) {
+    const rot = new THREE.Euler(this.pitch, this.yaw, 0);
+    const off = this.offset.clone().applyEuler(rot);
+    const desired = off.applyQuaternion(this.target.quaternion).add(this.target.position);
+    const stiffness = 5;
+    this.current.lerp(desired, 1 - Math.exp(-stiffness * dt));
+    this.cam.position.copy(this.current);
+    this.look.copy(this.target.position);
+    this.cam.lookAt(this.look);
+  }
+
+  setOrbit(yaw: number, pitch: number) {
+    this.yaw = THREE.MathUtils.clamp(yaw, THREE.MathUtils.degToRad(-60), THREE.MathUtils.degToRad(60));
+    this.pitch = THREE.MathUtils.clamp(pitch, THREE.MathUtils.degToRad(-60), THREE.MathUtils.degToRad(60));
+  }
+}
+

--- a/client/src/game/spawn.ts
+++ b/client/src/game/spawn.ts
@@ -1,0 +1,13 @@
+import * as THREE from 'three';
+import { buildRaptorLike, buildDragonLike } from '../aircraft/models';
+import type { AircraftChoice } from '../ui/landing';
+
+export function createAircraft(choice: AircraftChoice) {
+  switch (choice) {
+    case 'dragon':
+      return buildDragonLike();
+    case 'raptor':
+    default:
+      return buildRaptorLike();
+  }
+}

--- a/client/src/hud/hud.ts
+++ b/client/src/hud/hud.ts
@@ -1,0 +1,41 @@
+export interface HUDData {
+  spd: number;
+  alt: number;
+  pit: number;
+  rol: number;
+  hp: number;
+  name: string;
+  aircraft: string;
+}
+
+export function createHUD() {
+  const hud = document.createElement('div');
+  hud.style.position = 'absolute';
+  hud.style.top = '10px';
+  hud.style.left = '10px';
+  hud.style.color = 'white';
+  hud.style.fontFamily = 'monospace';
+  hud.style.whiteSpace = 'pre';
+  document.body.appendChild(hud);
+
+  const killed = document.createElement('div');
+  killed.style.position = 'absolute';
+  killed.style.top = '50%';
+  killed.style.left = '50%';
+  killed.style.transform = 'translate(-50%, -50%)';
+  killed.style.color = 'red';
+  killed.style.fontFamily = 'sans-serif';
+  killed.style.fontSize = '32px';
+  killed.style.display = 'none';
+  killed.textContent = 'KILLED — press R to respawn';
+  document.body.appendChild(killed);
+
+  return {
+    update(d: HUDData) {
+      hud.textContent =
+        `SPD ${d.spd.toFixed(0)}kn\nALT ${d.alt.toFixed(0)}m\nPIT ${d.pit.toFixed(0)}\u00b0\nROL ${d.rol.toFixed(0)}\u00b0\nHP ${d.hp}\nACFT ${d.aircraft}\nNAME ${d.name}`;
+      killed.style.display = d.hp <= 0 ? 'block' : 'none';
+    },
+  };
+}
+

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,202 +1,250 @@
 import * as THREE from 'three';
 import { FlightState, FlightInput, step } from './physics/flight';
 import { connect, sendState, sendProjectile, Snapshot, id as clientId } from './net/socket';
+import { showLanding, AircraftChoice } from './ui/landing';
+import { createAircraft } from './game/spawn';
+import { createHUD } from './hud/hud';
+import { ChaseCamera } from './cam/chase';
 
 const canvas = document.getElementById('app') as HTMLCanvasElement;
 const renderer = new THREE.WebGLRenderer({ canvas });
 renderer.setSize(window.innerWidth, window.innerHeight);
 
-const scene = new THREE.Scene();
-const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-camera.position.set(0, 2, 5);
+showLanding(startGame);
 
-const light = new THREE.HemisphereLight(0xffffff, 0x444444);
-scene.add(light);
+function startGame(result: { username: string; aircraft: AircraftChoice }) {
+  const { username, aircraft } = result;
 
-// Local aircraft
-const planeGeom = new THREE.BoxGeometry(1, 0.2, 3);
-const planeMat = new THREE.MeshStandardMaterial({ color: 0x00ff00 });
-const plane = new THREE.Mesh(planeGeom, planeMat);
-scene.add(plane);
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x87ceeb);
+  scene.fog = new THREE.Fog(0x87ceeb, 50, 300);
 
-// Remote aircraft
-const remoteMat = new THREE.MeshStandardMaterial({ color: 0xff0000 });
-const remote = new THREE.Mesh(planeGeom, remoteMat);
-scene.add(remote);
+  const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
 
-const state: FlightState = {
-  position: new THREE.Vector3(0, 5, 0),
-  velocity: new THREE.Vector3(),
-  orientation: new THREE.Quaternion(),
-  angularVelocity: new THREE.Vector3(),
-  throttle: 0,
-};
+  const sun = new THREE.DirectionalLight(0xffffff, 1);
+  sun.position.set(10, 20, 10);
+  scene.add(sun);
+  scene.add(new THREE.AmbientLight(0x404040));
 
-const input: FlightInput = { pitch: 0, roll: 0, yaw: 0 };
-let hp = 3;
+  const groundGeo = new THREE.PlaneGeometry(1000, 1000);
+  const groundMat = new THREE.MeshStandardMaterial({ color: 0x555555 });
+  const ground = new THREE.Mesh(groundGeo, groundMat);
+  ground.rotation.x = -Math.PI / 2;
+  scene.add(ground);
 
-const hud = document.createElement('div');
-hud.style.position = 'absolute';
-hud.style.top = '10px';
-hud.style.left = '10px';
-hud.style.color = 'white';
-hud.style.fontFamily = 'monospace';
-hud.style.whiteSpace = 'pre';
-document.body.appendChild(hud);
+  const local = createAircraft(aircraft);
+  scene.add(local);
 
-const remoteTarget = { pos: new THREE.Vector3(), quat: new THREE.Quaternion() };
-const remoteCurrent = { pos: new THREE.Vector3(), quat: new THREE.Quaternion() };
+  const state: FlightState = {
+    position: new THREE.Vector3(0, 5, 0),
+    velocity: new THREE.Vector3(),
+    orientation: new THREE.Quaternion(),
+    angularVelocity: new THREE.Vector3(),
+    throttle: 0,
+  };
 
-const projectiles = new Map<string, { mesh: THREE.Mesh; vel: THREE.Vector3; ttl: number }>();
+  const input: FlightInput = { pitch: 0, roll: 0, yaw: 0 };
+  let hp = 1;
 
-function handleSnapshot(snap: Snapshot) {
-  const self = clientId();
-  const seenProj = new Set<string>();
-  snap.players.forEach((p) => {
-    if (p.id === self) {
-      if (p.state.hp !== undefined) hp = p.state.hp;
-    } else {
-      remoteTarget.pos.fromArray(p.state.pos);
-      remoteTarget.quat.set(...p.state.quat);
-    }
-  });
-  snap.projectiles.forEach((pr) => {
-    seenProj.add(pr.id);
-    let entry = projectiles.get(pr.id);
-    if (!entry) {
-      const mesh = new THREE.Mesh(new THREE.SphereGeometry(0.05), new THREE.MeshBasicMaterial({ color: 0xffff00 }));
-      mesh.position.fromArray(pr.pos);
-      scene.add(mesh);
-      entry = { mesh, vel: new THREE.Vector3(), ttl: 2 };
-      projectiles.set(pr.id, entry);
-    } else {
-      const newPos = new THREE.Vector3().fromArray(pr.pos);
-      entry.vel.copy(newPos.clone().sub(entry.mesh.position));
-      entry.mesh.position.copy(newPos);
-      entry.ttl = 2;
-    }
-  });
-  for (const [id, p] of projectiles) {
-    if (!seenProj.has(id)) {
-      scene.remove(p.mesh);
-      projectiles.delete(id);
-    }
-  }
-}
+  const hud = createHUD();
+  const chase = new ChaseCamera(camera, local);
 
-function handleHit(id: string) {
-  if (id === clientId()) {
-    hp = Math.max(0, hp - 1);
-  }
-}
+  const remotes = new Map<string, {
+    mesh: THREE.Group;
+    targetPos: THREE.Vector3;
+    targetQuat: THREE.Quaternion;
+    currentPos: THREE.Vector3;
+    currentQuat: THREE.Quaternion;
+    aircraft: AircraftChoice;
+  }>();
 
-connect(handleSnapshot, handleHit);
-
-window.addEventListener('keydown', (e) => {
-  switch (e.key) {
-    case 'w':
-      input.pitch = 1;
-      break;
-    case 's':
-      input.pitch = -1;
-      break;
-    case 'a':
-      input.roll = 1;
-      break;
-    case 'd':
-      input.roll = -1;
-      break;
-    case 'q':
-      input.yaw = 1;
-      break;
-    case 'e':
-      input.yaw = -1;
-      break;
-    case 'Shift':
-    case 'ShiftLeft':
-    case 'ShiftRight':
-      state.throttle = Math.min(1, state.throttle + 0.1);
-      break;
-    case 'Control':
-    case 'ControlLeft':
-    case 'ControlRight':
-      state.throttle = Math.max(0, state.throttle - 0.1);
-      break;
-    case ' ':
-      fire();
-      break;
-  }
-});
-
-window.addEventListener('keyup', (e) => {
-  switch (e.key) {
-    case 'w':
-    case 's':
-      input.pitch = 0;
-      break;
-    case 'a':
-    case 'd':
-      input.roll = 0;
-      break;
-    case 'q':
-    case 'e':
-      input.yaw = 0;
-      break;
-  }
-});
-
-function fire() {
-  const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(state.orientation).normalize();
-  const pos = state.position.clone().add(forward.clone().multiplyScalar(1));
-  const vel = forward.clone().multiplyScalar(50).add(state.velocity);
-  const id = sendProjectile(pos, vel, 2);
-  if (id) {
-    const mesh = new THREE.Mesh(new THREE.SphereGeometry(0.05), new THREE.MeshBasicMaterial({ color: 0xffff00 }));
-    mesh.position.copy(pos);
-    scene.add(mesh);
-    projectiles.set(id, { mesh, vel, ttl: 2 });
-  }
-}
-
-setInterval(() => sendState(state), 50);
-
-let last = performance.now();
-let acc = 0;
-const FIXED_DT = 1 / 120;
-
-function animate(now: number) {
-  const dt = (now - last) / 1000;
-  last = now;
-  acc += dt;
-  while (acc >= FIXED_DT) {
-    step(state, input, FIXED_DT);
-    for (const [id, p] of projectiles) {
-      p.mesh.position.add(p.vel.clone().multiplyScalar(FIXED_DT));
-      p.ttl -= FIXED_DT;
-      if (p.ttl <= 0) {
-        scene.remove(p.mesh);
-        projectiles.delete(id);
+  function handleSnapshot(snap: Snapshot) {
+    const self = clientId();
+    const seen = new Set<string>();
+    snap.players.forEach((p) => {
+      if (p.id === self) {
+        if (p.state.hp !== undefined) hp = p.state.hp;
+        return;
+      }
+      seen.add(p.id);
+      let entry = remotes.get(p.id);
+      if (!entry) {
+        const mesh = createAircraft(p.aircraft || 'raptor');
+        scene.add(mesh);
+        entry = {
+          mesh,
+          targetPos: new THREE.Vector3(),
+          targetQuat: new THREE.Quaternion(),
+          currentPos: new THREE.Vector3(),
+          currentQuat: new THREE.Quaternion(),
+          aircraft: p.aircraft || 'raptor',
+        };
+        remotes.set(p.id, entry);
+      }
+      entry.targetPos.fromArray(p.state.pos);
+      entry.targetQuat.set(...p.state.quat);
+    });
+    for (const [id, entry] of remotes) {
+      if (!seen.has(id)) {
+        scene.remove(entry.mesh);
+        remotes.delete(id);
       }
     }
-    acc -= FIXED_DT;
   }
 
-  plane.position.copy(state.position);
-  plane.quaternion.copy(state.orientation);
+  function handleHit(id: string) {
+    if (id === clientId()) {
+      hp = Math.max(0, hp - 1);
+    }
+  }
 
-  remoteCurrent.pos.lerp(remoteTarget.pos, 0.1);
-  remoteCurrent.quat.slerp(remoteTarget.quat, 0.1);
-  remote.position.copy(remoteCurrent.pos);
-  remote.quaternion.copy(remoteCurrent.quat);
+  connect(username, aircraft, handleSnapshot, handleHit);
 
-  const speed = state.velocity.length() * 1.94384; // m/s -> knots
-  const altitude = state.position.y;
-  const euler = new THREE.Euler().setFromQuaternion(state.orientation, 'XYZ');
-  const pitch = THREE.MathUtils.radToDeg(euler.x);
-  const roll = THREE.MathUtils.radToDeg(euler.z);
-  hud.textContent = `SPD ${speed.toFixed(0)}kt\nALT ${altitude.toFixed(0)}m\nPIT ${pitch.toFixed(0)}\u00b0\nROL ${roll.toFixed(0)}\u00b0\nHP ${hp}`;
+  window.addEventListener('keydown', (e) => {
+    if (orbit) return;
+    switch (e.key) {
+      case 'w':
+        input.pitch = 1;
+        break;
+      case 's':
+        input.pitch = -1;
+        break;
+      case 'a':
+        input.roll = 1;
+        break;
+      case 'd':
+        input.roll = -1;
+        break;
+      case 'q':
+        input.yaw = 1;
+        break;
+      case 'e':
+        input.yaw = -1;
+        break;
+      case 'Shift':
+      case 'ShiftLeft':
+      case 'ShiftRight':
+        state.throttle = Math.min(1, state.throttle + 0.1);
+        break;
+      case 'Control':
+      case 'ControlLeft':
+      case 'ControlRight':
+        state.throttle = Math.max(0, state.throttle - 0.1);
+        break;
+      case ' ':
+        fire();
+        break;
+      case 'r':
+      case 'R':
+        hp = 1;
+        state.position.set(0, 5, 0);
+        state.velocity.set(0, 0, 0);
+        state.orientation.set(0, 0, 0, 1);
+        break;
+    }
+  });
 
-  renderer.render(scene, camera);
+  window.addEventListener('keyup', (e) => {
+    switch (e.key) {
+      case 'w':
+      case 's':
+        input.pitch = 0;
+        break;
+      case 'a':
+      case 'd':
+        input.roll = 0;
+        break;
+      case 'q':
+      case 'e':
+        input.yaw = 0;
+        break;
+    }
+  });
+
+  let orbit = false;
+  let yaw = 0;
+  let pitch = 0;
+  window.addEventListener('mousedown', (e) => {
+    if (e.button === 2) orbit = true;
+  });
+  window.addEventListener('mouseup', (e) => {
+    if (e.button === 2) orbit = false;
+  });
+  window.addEventListener('mousemove', (e) => {
+    if (orbit) {
+      yaw -= e.movementX * 0.005;
+      pitch -= e.movementY * 0.005;
+      chase.setOrbit(yaw, pitch);
+    }
+  });
+  window.addEventListener('contextmenu', (e) => e.preventDefault());
+
+  const projectiles = new Map<string, { mesh: THREE.Mesh; vel: THREE.Vector3; ttl: number }>();
+
+  function fire() {
+    const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(state.orientation).normalize();
+    const pos = state.position.clone().add(forward.clone().multiplyScalar(1));
+    const vel = forward.clone().multiplyScalar(50).add(state.velocity);
+    const id = sendProjectile(pos, vel, 2);
+    if (id) {
+      const mesh = new THREE.Mesh(new THREE.SphereGeometry(0.05), new THREE.MeshBasicMaterial({ color: 0xffff00 }));
+      mesh.position.copy(pos);
+      scene.add(mesh);
+      projectiles.set(id, { mesh, vel, ttl: 2 });
+    }
+  }
+
+  setInterval(() => sendState(state), 50);
+
+  let last = performance.now();
+  let acc = 0;
+  const FIXED_DT = 1 / 120;
+
+  function animate(now: number) {
+    const dt = (now - last) / 1000;
+    last = now;
+    acc += dt;
+    while (acc >= FIXED_DT) {
+      step(state, input, FIXED_DT);
+      for (const [id, p] of projectiles) {
+        p.mesh.position.add(p.vel.clone().multiplyScalar(FIXED_DT));
+        p.ttl -= FIXED_DT;
+        if (p.ttl <= 0) {
+          scene.remove(p.mesh);
+          projectiles.delete(id);
+        }
+      }
+      acc -= FIXED_DT;
+    }
+
+    local.position.copy(state.position);
+    local.quaternion.copy(state.orientation);
+
+    remotes.forEach((entry) => {
+      entry.currentPos.lerp(entry.targetPos, 0.1);
+      entry.currentQuat.slerp(entry.targetQuat, 0.1);
+      entry.mesh.position.copy(entry.currentPos);
+      entry.mesh.quaternion.copy(entry.currentQuat);
+    });
+
+    const speed = state.velocity.length() * 1.94384;
+    const altitude = state.position.y;
+    const euler = new THREE.Euler().setFromQuaternion(state.orientation, 'XYZ');
+    const pitchDeg = THREE.MathUtils.radToDeg(euler.x);
+    const rollDeg = THREE.MathUtils.radToDeg(euler.z);
+    hud.update({
+      spd: speed,
+      alt: altitude,
+      pit: pitchDeg,
+      rol: rollDeg,
+      hp,
+      name: username,
+      aircraft: aircraft === 'raptor' ? 'Raptor-like' : 'Mighty-Dragon-like',
+    });
+
+    chase.update(dt);
+    renderer.render(scene, camera);
+    requestAnimationFrame(animate);
+  }
   requestAnimationFrame(animate);
 }
-requestAnimationFrame(animate);

--- a/client/src/ui/landing.css
+++ b/client/src/ui/landing.css
@@ -1,0 +1,50 @@
+.landing-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  backdrop-filter: blur(4px);
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+}
+
+.landing-box {
+  background: #222;
+  padding: 20px;
+  color: #fff;
+  font-family: sans-serif;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 260px;
+}
+
+.aircraft-cards {
+  display: flex;
+  gap: 10px;
+}
+
+.aircraft-card {
+  flex: 1;
+  background: #333;
+  padding: 8px;
+  text-align: center;
+  border: 2px solid transparent;
+}
+
+.aircraft-card.selected {
+  border-color: #0af;
+}
+
+.aircraft-card .thumb {
+  font-size: 32px;
+}
+
+.enter-btn {
+  padding: 8px;
+}
+

--- a/client/src/ui/landing.ts
+++ b/client/src/ui/landing.ts
@@ -1,0 +1,92 @@
+import './landing.css';
+
+export type AircraftChoice = 'raptor' | 'dragon';
+
+export interface LandingResult {
+  username: string;
+  aircraft: AircraftChoice;
+}
+
+/**
+ * Shows the landing screen allowing the user to pick a username and aircraft.
+ * Calls `onEnter` once the user submits valid data.
+ */
+export function showLanding(onEnter: (result: LandingResult) => void) {
+  const storedName = localStorage.getItem('fsim.username') || '';
+  const storedAircraft = (localStorage.getItem('fsim.aircraft') as AircraftChoice) || 'raptor';
+
+  const overlay = document.createElement('div');
+  overlay.className = 'landing-overlay';
+
+  const box = document.createElement('div');
+  box.className = 'landing-box';
+
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.placeholder = 'Username';
+  nameInput.value = storedName;
+  nameInput.maxLength = 20;
+
+  const cards = document.createElement('div');
+  cards.className = 'aircraft-cards';
+
+  const cardRaptor = createCard('Raptor-like', 'raptor', storedAircraft === 'raptor');
+  const cardDragon = createCard('Mighty-Dragon-like', 'dragon', storedAircraft === 'dragon');
+
+  cards.append(cardRaptor.el, cardDragon.el);
+
+  let selected: AircraftChoice = storedAircraft;
+  cardRaptor.btn.addEventListener('click', () => {
+    selected = 'raptor';
+    cardRaptor.el.classList.add('selected');
+    cardDragon.el.classList.remove('selected');
+  });
+  cardDragon.btn.addEventListener('click', () => {
+    selected = 'dragon';
+    cardDragon.el.classList.add('selected');
+    cardRaptor.el.classList.remove('selected');
+  });
+
+  const enterBtn = document.createElement('button');
+  enterBtn.textContent = 'Enter';
+  enterBtn.className = 'enter-btn';
+
+  enterBtn.addEventListener('click', () => {
+    const username = nameInput.value.trim();
+    if (username.length < 3 || username.length > 20) {
+      alert('Username must be 3-20 characters');
+      return;
+    }
+    localStorage.setItem('fsim.username', username);
+    localStorage.setItem('fsim.aircraft', selected);
+    overlay.remove();
+    onEnter({ username, aircraft: selected });
+  });
+
+  box.append(nameInput, cards, enterBtn);
+  overlay.appendChild(box);
+  document.body.appendChild(overlay);
+
+  nameInput.focus();
+}
+
+function createCard(label: string, id: AircraftChoice, selected: boolean) {
+  const el = document.createElement('div');
+  el.className = 'aircraft-card' + (selected ? ' selected' : '');
+
+  const thumb = document.createElement('div');
+  thumb.className = 'thumb';
+  // Placeholder thumbnail using emoji
+  thumb.textContent = id === 'raptor' ? '\ud83e\udd85' : '\ud83e\udd96';
+
+  const title = document.createElement('div');
+  title.textContent = label;
+
+  const btn = document.createElement('button');
+  btn.textContent = 'Select';
+
+  el.append(thumb, title, btn);
+
+  return { el, btn };
+}
+


### PR DESCRIPTION
## Summary
- add landing screen with username input and aircraft chooser
- introduce simple procedural aircraft models and chase camera
- expand HUD and networking to include name and aircraft

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a33d406cf88328b4780743f38b0c9c