### PR TITLE
Enable practice mode and improve flight controls

### DIFF
--- a/client/src/cam/chase.ts
+++ b/client/src/cam/chase.ts
@@ -46,7 +46,11 @@ export class ChaseCamera {
     const stiffness = 5; // critical damping approximation
     this.current.lerp(desired, 1 - Math.exp(-stiffness * dt));
     this.cam.position.copy(this.current);
-    this.look.copy(this.target.position);
+    // look a little ahead of the aircraft to reduce jitter
+    this.look
+      .set(0, 0, -10)
+      .applyQuaternion(this.target.quaternion)
+      .add(this.target.position);
     this.cam.lookAt(this.look);
   }
 }

--- a/client/src/mode/mode.ts
+++ b/client/src/mode/mode.ts
@@ -1,0 +1,15 @@
+export enum GameMode {
+  Practice = 'practice',
+  Multiplayer = 'multiplayer',
+}
+
+const KEY = 'fsim.mode';
+
+export function getMode(): GameMode {
+  const stored = localStorage.getItem(KEY) as GameMode | null;
+  return stored === GameMode.Multiplayer ? GameMode.Multiplayer : GameMode.Practice;
+}
+
+export function setMode(mode: GameMode) {
+  localStorage.setItem(KEY, mode);
+}

--- a/client/src/ui/pause.ts
+++ b/client/src/ui/pause.ts
@@ -1,0 +1,71 @@
+import { GameMode, setMode } from '../mode/mode';
+
+export function createPauseMenu(
+  mode: GameMode,
+  onResume: () => void,
+  onReset: () => void
+) {
+  const overlay = document.createElement('div');
+  overlay.style.position = 'absolute';
+  overlay.style.top = '0';
+  overlay.style.left = '0';
+  overlay.style.right = '0';
+  overlay.style.bottom = '0';
+  overlay.style.display = 'none';
+  overlay.style.alignItems = 'center';
+  overlay.style.justifyContent = 'center';
+  overlay.style.background = 'rgba(0,0,0,0.6)';
+  document.body.appendChild(overlay);
+
+  const box = document.createElement('div');
+  box.style.background = '#222';
+  box.style.padding = '20px';
+  box.style.borderRadius = '8px';
+  box.style.display = 'flex';
+  box.style.flexDirection = 'column';
+  box.style.gap = '10px';
+  overlay.appendChild(box);
+
+  function makeBtn(label: string, handler: () => void) {
+    const b = document.createElement('button');
+    b.textContent = label;
+    b.addEventListener('click', handler);
+    return b;
+  }
+
+  const resume = makeBtn('Resume', () => {
+    overlay.style.display = 'none';
+    onResume();
+  });
+
+  const reset = makeBtn('Reset Session', () => {
+    overlay.style.display = 'none';
+    onReset();
+  });
+
+  const switchBtn = makeBtn('', () => {
+    const next = mode === GameMode.Practice ? GameMode.Multiplayer : GameMode.Practice;
+    setMode(next);
+    window.location.reload();
+  });
+
+  box.append(resume, reset, switchBtn);
+
+  function updateMode(m: GameMode) {
+    mode = m;
+    switchBtn.textContent =
+      mode === GameMode.Practice ? 'Switch to Multiplayer' : 'Switch to Practice';
+  }
+
+  updateMode(mode);
+
+  return {
+    show(m: GameMode) {
+      updateMode(m);
+      overlay.style.display = 'flex';
+    },
+    hide() {
+      overlay.style.display = 'none';
+    },
+  };
+}

--- a/client/src/ui/statusChip.ts
+++ b/client/src/ui/statusChip.ts
@@ -1,0 +1,27 @@
+import { GameMode } from '../mode/mode';
+
+export function createStatusChip(mode: GameMode) {
+  const chip = document.createElement('div');
+  chip.style.position = 'absolute';
+  chip.style.top = '10px';
+  chip.style.right = '10px';
+  chip.style.padding = '4px 8px';
+  chip.style.background = 'rgba(0,0,0,0.5)';
+  chip.style.color = 'white';
+  chip.style.fontFamily = 'sans-serif';
+  chip.style.fontSize = '12px';
+  chip.style.borderRadius = '4px';
+  document.body.appendChild(chip);
+
+  function label(m: GameMode) {
+    return m === GameMode.Practice ? 'Mode: Practice' : 'Mode: Multiplayer';
+  }
+
+  chip.textContent = label(mode);
+
+  return {
+    set(m: GameMode) {
+      chip.textContent = label(m);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- centralize keyboard & mouse handling with pointer-lock based mouselook
- add practice mode with offline play, pause menu, and status chip
- improve chase camera follow behavior

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3437cdec48328ae52a7ef1d191597