### PR TITLE
feat: add boot overlay and safe canvas creation

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <title>Flight Sim MVP</title>
 </head>
-<body>
-  <canvas id="app"></canvas>
+<body style="background:#0a0f17;">
+  <div id="app"></div>
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/client/src/boot/boot.ts
+++ b/client/src/boot/boot.ts
@@ -1,0 +1,72 @@
+/** Boot overlay and helpers to avoid blank screen. */
+class Overlay {
+  private logEl: HTMLDivElement;
+  private errEl: HTMLDivElement;
+
+  constructor() {
+    const root = document.createElement('div');
+    root.style.position = 'fixed';
+    root.style.top = '0';
+    root.style.left = '0';
+    root.style.fontFamily = 'monospace';
+    root.style.fontSize = '12px';
+    root.style.color = '#fff';
+    root.style.pointerEvents = 'none';
+    root.style.zIndex = '9999';
+
+    this.logEl = document.createElement('div');
+    this.logEl.textContent = 'Booting...\n';
+    root.appendChild(this.logEl);
+
+    this.errEl = document.createElement('pre');
+    this.errEl.style.background = 'rgba(255,0,0,0.8)';
+    this.errEl.style.color = '#fff';
+    this.errEl.style.marginTop = '4px';
+    this.errEl.style.display = 'none';
+    this.errEl.style.whiteSpace = 'pre-wrap';
+    root.appendChild(this.errEl);
+
+    document.body.appendChild(root);
+  }
+
+  step(msg: string) {
+    this.logEl.textContent += msg + '\n';
+  }
+
+  error(msg: string) {
+    this.errEl.style.display = 'block';
+    this.errEl.textContent = msg;
+    console.error(msg);
+  }
+}
+
+export const BootOverlay = new Overlay();
+
+// Global error handlers
+window.addEventListener('error', (e) => {
+  BootOverlay.error(e.error?.stack || e.message);
+});
+window.addEventListener('unhandledrejection', (e) => {
+  BootOverlay.error(String(e.reason));
+});
+
+export function must<T>(value: T | null | undefined, label: string): T {
+  if (!value) throw new Error(label);
+  return value;
+}
+
+export async function tryStep(label: string, fn: () => void | Promise<void>) {
+  try {
+    BootOverlay.step(label);
+    await fn();
+  } catch (e: any) {
+    BootOverlay.error(e?.stack || e?.message || String(e));
+    throw e;
+  }
+}
+
+export function ensureWebGL() {
+  const c = document.createElement('canvas');
+  const gl = c.getContext('webgl') || c.getContext('webgl2');
+  if (!gl) throw new Error('WebGL not supported');
+}


### PR DESCRIPTION
## Summary
- add BootOverlay to display boot progress and capture errors
- create WebGL canvas programmatically and log boot steps
- replace static canvas with div and dark background in index.html

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a35dd178348328904f170d6d72d1bb