### PR TITLE
Fix quaternion integration and reset angular velocity on respawn

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -89,6 +89,7 @@ function startGame(result: { username: string; aircraft: AircraftChoice }) {
     state.position.set(0, 50, 0);
     state.velocity.set(0, 0, -30);
     state.orientation.set(0, 0, 0, 1);
+    state.angularVelocity.set(0, 0, 0);
     state.throttle = 0.6;
   }
   resetState();

--- a/client/src/physics/flight.ts
+++ b/client/src/physics/flight.ts
@@ -35,10 +35,14 @@ export function step(state: FlightState, input: FlightInput, dt: number) {
   // Integrate orientation
   const w = state.angularVelocity;
   const q = state.orientation;
-  const dq = new THREE.Quaternion(w.x, w.y, w.z, 0)
-    .multiply(q)
-    .multiplyScalar(0.5 * dt);
-  q.add(dq).normalize();
+  const dq = new THREE.Quaternion(w.x, w.y, w.z, 0).multiply(q);
+  // Scale derivative and integrate without relying on a non-existent
+  // Quaternion.multiplyScalar (previously causing multiply$Scalar errors).
+  q.x += dq.x * 0.5 * dt;
+  q.y += dq.y * 0.5 * dt;
+  q.z += dq.z * 0.5 * dt;
+  q.w += dq.w * 0.5 * dt;
+  q.normalize();
 
   // Force calculations
   const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(q);


### PR DESCRIPTION
## Summary
- Avoid invalid `multiplyScalar` on quaternions by manually scaling the derivative
- Reset aircraft angular velocity when respawning to ensure stable restart

## Testing
- `cd client && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a36289bb688328b4998df58e67d975