### PR TITLE
feat: implement chase camera and throttle control

### DIFF
--- a/client/src/input/controls.ts
+++ b/client/src/input/controls.ts
@@ -42,8 +42,10 @@ export class Controls {
       if (document.pointerLockElement === canvas) {
         this.yaw -= e.movementX * 0.002;
         this.pitch -= e.movementY * 0.002;
-        const limit = THREE.MathUtils.degToRad(60);
-        this.pitch = THREE.MathUtils.clamp(this.pitch, -limit, limit);
+        const yawLim = THREE.MathUtils.degToRad(90);
+        const pitchLim = THREE.MathUtils.degToRad(60);
+        this.yaw = THREE.MathUtils.clamp(this.yaw, -yawLim, yawLim);
+        this.pitch = THREE.MathUtils.clamp(this.pitch, -pitchLim, pitchLim);
       }
     });
     window.addEventListener('keydown', this.onKeyDown);
@@ -70,6 +72,12 @@ export class Controls {
       (this.keys.has('ControlLeft') || this.keys.has('ControlRight') ? -1 : 0);
     const fire = this.keys.has('Space');
     const respawn = this.keys.has('KeyR');
+
+    if (document.pointerLockElement !== this.canvas) {
+      this.yaw *= 0.9;
+      this.pitch *= 0.9;
+    }
+
     return {
       pitch,
       roll,

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -2,7 +2,13 @@ import * as THREE from 'three';
 import { BootOverlay, ensureWebGL, must, tryStep } from './boot/boot';
 import { Controls } from './input/controls';
 import { ChaseCamera } from './cam/chase';
-import { step, SimpleFlightInput, SimpleFlightState, H, isFiniteState } from './flight/simple';
+import {
+  step,
+  SimpleFlightInput,
+  SimpleFlightState,
+  H,
+  isFiniteState,
+} from './flight/simple';
 import { spawnLocal, respawn, LocalPlayer } from './game/spawn';
 import { createStatusChip } from './ui/statusChip';
 
@@ -48,6 +54,25 @@ const controls = new Controls(canvas);
 const chase = new ChaseCamera(camera);
 createStatusChip();
 
+const focusHint = document.createElement('div');
+focusHint.textContent = 'Click to focus / RMB to look';
+focusHint.style.position = 'absolute';
+focusHint.style.top = '50%';
+focusHint.style.left = '50%';
+focusHint.style.transform = 'translate(-50%, -50%)';
+focusHint.style.color = 'white';
+focusHint.style.background = 'rgba(0,0,0,0.5)';
+focusHint.style.padding = '8px 12px';
+focusHint.style.fontFamily = 'sans-serif';
+document.body.appendChild(focusHint);
+canvas.addEventListener(
+  'focus',
+  () => {
+    focusHint.remove();
+  },
+  { once: true }
+);
+
 const hud = document.createElement('div');
 hud.style.position = 'absolute';
 hud.style.top = '10px';
@@ -65,6 +90,10 @@ function updateHUD() {
 
 let last = performance.now();
 let acc = 0;
+const MIN_SPEED = 50;
+const MAX_SPEED = 250;
+const SPEED_RANGE = MAX_SPEED - MIN_SPEED;
+let throttle = (player.state.speedTarget - MIN_SPEED) / SPEED_RANGE;
 
 function loop(now: number) {
   const dt = (now - last) / 1000;
@@ -72,18 +101,16 @@ function loop(now: number) {
   acc += dt;
   const input = controls.getInputs();
 
+  throttle = THREE.MathUtils.clamp(throttle + input.throttle * dt, 0, 1);
+  player.state.speedTarget = MIN_SPEED + throttle * SPEED_RANGE;
+
   while (acc >= H) {
     const fi: SimpleFlightInput = {
       pitch: input.pitch,
       roll: input.roll,
       yaw: input.yaw,
-      throttle: input.throttle,
+      throttle: throttle,
     };
-    player.state.speedTarget = THREE.MathUtils.clamp(
-      player.state.speedTarget + fi.throttle * 20 * H,
-      50,
-      250
-    );
     step(player.state, fi, H);
     acc -= H;
   }
@@ -93,6 +120,7 @@ function loop(now: number) {
 
   if (input.respawn || !isFiniteState(player.state)) {
     respawn(player);
+    throttle = (player.state.speedTarget - MIN_SPEED) / SPEED_RANGE;
   }
 
   chase.update(dt, player.state, input.lookYaw, input.lookPitch);


### PR DESCRIPTION
## Summary
- keep camera in aircraft frame with smooth spring follow and yaw/pitch offsets
- add pointer-lock camera controls with recentering and yaw/pitch limits
- throttle control maps to target speed with Shift/Ctrl and shows focus hint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a36990619c83289c0b54fe1af414c4