### PR TITLE
Stabilize simple flight and chase camera

### DIFF
--- a/client/src/cam/chase.ts
+++ b/client/src/cam/chase.ts
@@ -1,7 +1,9 @@
 import * as THREE from 'three';
 import { SimpleFlightState } from '../flight/simple';
 
-const OFFSET = new THREE.Vector3(-12, 3.5, 0); // local offset (up, back)
+const CAM_BACK = 12;
+const CAM_UP = 3.5;
+const OFFSET = new THREE.Vector3(-CAM_BACK, CAM_UP, 0); // behind and above the craft
 const LOOK_AHEAD = 20;
 
 /** Third person chase camera with critically damped spring and mouse-look. */

--- a/client/src/flight/simple.ts
+++ b/client/src/flight/simple.ts
@@ -25,6 +25,7 @@ export const ROLL_MAX = 1.2;
 export const RATE_SMOOTH = 0.15;
 export const SPEED_GAIN = 1.5;
 export const COORD_YAW_GAIN = 0.2;
+export const DRAG_K = 0.0004;
 export const GROUND_Y = 0;
 export const SKY_Y = 4000;
 export const WORLD_HALF = 50000;
@@ -48,6 +49,8 @@ export function step(state: SimpleFlightState, input: SimpleFlightInput, h: numb
 
   const forward = new THREE.Vector3(1, 0, 0).applyQuaternion(q);
   state.speed += (state.speedTarget - state.speed) * SPEED_GAIN * h;
+  state.speed -= DRAG_K * state.speed * state.speed * h;
+  if (state.speed < 0) state.speed = 0;
   state.vel.copy(forward).multiplyScalar(state.speed);
   state.pos.addScaledVector(state.vel, h);
 


### PR DESCRIPTION
## Summary
- apply small quadratic drag to simple flight speed for better throttle response
- parameterize chase camera offset to stay behind and above the craft

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a36ea8fe44832899e3d800471cf4e8