### PR TITLE
fix: remove stray headers from client files

### DIFF
--- a/client/src/boot/boot.ts
+++ b/client/src/boot/boot.ts
@@ -1,4 +1,3 @@
-/client/src/boot/boot.ts
 export class BootOverlay {
   private element: HTMLDivElement;
   private logs: string[] = [];

--- a/client/src/cam/chase.ts
+++ b/client/src/cam/chase.ts
@@ -1,4 +1,3 @@
-/client/src/cam/chase.ts
 import * as THREE from 'three';
 
 export class ChaseCamera {

--- a/client/src/flight/simple.ts
+++ b/client/src/flight/simple.ts
@@ -1,4 +1,3 @@
-/client/src/flight/simple.ts
 import * as THREE from 'three';
 
 export class SimpleFlight {

--- a/client/src/game/spawn.ts
+++ b/client/src/game/spawn.ts
@@ -1,43 +1,15 @@
-/client/src/cam/chase.ts
-import * as THREE from 'three';
+import { SimpleFlight } from '../flight/simple';
 
-export class ChaseCamera {
-  private camera: THREE.PerspectiveCamera;
-  private position = new THREE.Vector3();
-  private velocity = new THREE.Vector3();
-  private mouseOffset = new THREE.Vector2();
-  private readonly CAM_UP = 2;
-  private readonly CAM_BACK = 10;
-  private readonly LOOK_AHEAD = 10;
-  private readonly SPRING_K = 25;
-  private readonly DAMPING = 10;
+export class SpawnManager {
+  constructor(private flight: SimpleFlight) {}
 
-  constructor(camera: THREE.PerspectiveCamera) {
-    this.camera = camera;
+  spawn() {
+    this.flight.reset();
   }
 
-  update(aircraft: { position: THREE.Vector3; quaternion: THREE.Quaternion }, mouse: { x: number; y: number }, h: number) {
-    const offset = new THREE.Vector3(0, this.CAM_UP, -this.CAM_BACK).applyQuaternion(aircraft.quaternion);
-    const desired = aircraft.position.clone().add(offset);
-    const look = aircraft.position.clone().add(
-      new THREE.Vector3(0, 0, this.LOOK_AHEAD).applyQuaternion(aircraft.quaternion)
-    );
-
-    const mouseAdjust = new THREE.Vector3(0, Math.max(-Math.PI / 4, Math.min(Math.PI / 4, this.mouseOffset.y)), this.mouseOffset.x);
-    look.add(new THREE.Vector3(0, mouseAdjust.y * 5, 0).applyQuaternion(aircraft.quaternion));
-
-    const delta = desired.clone().sub(this.position);
-    const accel = delta.multiplyScalar(this.SPRING_K).sub(this.velocity.clone().multiplyScalar(this.DAMPING));
-    this.velocity.addScaledVector(accel, h);
-    this.position.addScaledVector(this.velocity, h);
-
-    this.camera.position.copy(this.position);
-    this.camera.lookAt(look);
-
-    this.mouseOffset.x = THREE.MathUtils.lerp(this.mouseOffset.x, mouse.x, 5 * h);
-    this.mouseOffset.y = THREE.MathUtils.lerp(this.mouseOffset.y, mouse.y, 5 * h);
-    if (!mouse.x && !mouse.y) {
-      this.mouseOffset.lerp(new THREE.Vector2(), 5 * h);
+  update(inputs: { respawn: boolean }) {
+    if (inputs.respawn) {
+      this.spawn();
     }
   }
 }

--- a/client/src/hud/hud.ts
+++ b/client/src/hud/hud.ts
@@ -1,4 +1,3 @@
-/client/src/hud/hud.ts
 export class HUD {
   private element: HTMLDivElement;
 

--- a/client/src/input/controls.ts
+++ b/client/src/input/controls.ts
@@ -1,4 +1,3 @@
-/client/src/input/controls.ts
 import * as THREE from 'three';
 
 export class Controls {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,4 +1,3 @@
-/client/src/main.ts
 import * as THREE from 'three';
 import { Controls } from './input/controls';
 import { SimpleFlight } from './flight/simple';

--- a/client/src/mode/mode.ts
+++ b/client/src/mode/mode.ts
@@ -1,4 +1,3 @@
-/client/src/mode/mode.ts
 export class ModeManager {
   private mode: string;
 
@@ -8,7 +7,6 @@ export class ModeManager {
   }
 
   getMode() {
-0389
     return this.mode;
   }
 

--- a/client/src/net/types.ts
+++ b/client/src/net/types.ts
@@ -1,4 +1,3 @@
-/client/src/net/types.ts
 export interface NetworkData {
   // Placeholder; no-op in Practice mode
 }


### PR DESCRIPTION
## Summary
- remove stray file path strings from TypeScript modules
- restore SpawnManager implementation

## Testing
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_68a5f2bdaeac832888dd0eb42b18d449