### PR TITLE
Tighten chase camera distance

### DIFF
--- a/client/src/cam/chase.ts
+++ b/client/src/cam/chase.ts
@@ -6,7 +6,7 @@ export class ChaseCamera {
   private velocity = new THREE.Vector3();
   private mouseOffset = new THREE.Vector2();
   private readonly CAM_UP = 2;
-  private readonly CAM_BACK = 10;
+  private readonly CAM_BACK = 4;
   private readonly LOOK_AHEAD = 10;
   private readonly SPRING_K = 25;
   private readonly DAMPING = 10;


### PR DESCRIPTION
## Summary
- Bring chase camera closer to the aircraft by reducing rear offset

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a70536e9c88328859e6933d7e5feff