### PR TITLE
feat: add loading screen and fix camera orientation

### DIFF
--- a/client/src/boot/boot.ts
+++ b/client/src/boot/boot.ts
@@ -1,29 +1,40 @@
 export class BootOverlay {
   private element: HTMLDivElement;
-  private logs: string[] = [];
 
   constructor() {
     this.element = document.createElement('div');
-    this.element.style.position = 'absolute';
-    this.element.style.top = '10px';
-    this.element.style.left = '10px';
-    this.element.style.color = 'white';
-    this.element.style.background = 'rgba(0,0,0,0.5)';
-    this.element.style.padding = '5px';
+    Object.assign(this.element.style, {
+      position: 'fixed',
+      top: '0',
+      left: '0',
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: '#000',
+      color: '#fff',
+      fontFamily: 'sans-serif',
+      fontSize: '24px',
+      zIndex: '1000',
+    } as CSSStyleDeclaration);
+    this.element.innerText = 'Loading...';
     document.body.appendChild(this.element);
 
     window.addEventListener('error', (e) => this.handleError(e.message));
-    window.addEventListener('unhandledrejection', (e) => this.handleError(e.reason));
+    window.addEventListener('unhandledrejection', (e) => this.handleError(String(e.reason)));
   }
 
   log(message: string) {
-    this.logs.push(message);
-    if (this.logs.length > 5) this.logs.shift();
-    this.element.innerText = this.logs.join('\n');
+    this.element.innerText = message;
+  }
+
+  done() {
+    this.element.remove();
   }
 
   private handleError(message: string) {
-    this.element.style.background = 'rgba(255,0,0,0.5)';
-    this.element.innerText = `Error: ${message}\n` + this.logs.join('\n');
+    this.element.style.background = 'rgba(255,0,0,0.8)';
+    this.element.innerText = `Error: ${message}`;
   }
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -35,32 +35,6 @@ export class FlightSim {
     this.scene = new THREE.Scene();
     this.camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 10000);
 
-    this.boot.log('Setting up ground and sky...');
-    const ground = new THREE.Mesh(
-      new THREE.PlaneGeometry(100000, 100000),
-      new THREE.MeshBasicMaterial({ color: 0x228B22 })
-    );
-    ground.rotation.x = -Math.PI / 2;
-    this.scene.add(ground);
-    this.scene.background = new THREE.Color(0x87CEEB);
-
-    this.boot.log('Loading aircraft model...');
-    const loader = new GLTFLoader();
-    loader.load(
-      '/models/f-22_raptor_-_fighter_jet_-_free.glb',
-      (gltf) => {
-        this.aircraft = gltf.scene;
-        this.aircraft.scale.set(0.01, 0.01, 0.01);
-        this.scene.add(this.aircraft);
-        this.boot.log('Aircraft ready.');
-      },
-      undefined,
-      (err) => {
-        console.error('Failed to load aircraft model', err);
-      }
-    );
-
-    this.boot.log('Initializing systems...');
     this.controls = new Controls(this.renderer.domElement);
     this.flight = new SimpleFlight();
     this.chaseCamera = new ChaseCamera(this.camera);
@@ -68,8 +42,91 @@ export class FlightSim {
     this.mode = new ModeManager();
     this.hud = new HUD();
 
-    this.boot.log('Starting game loop...');
-    this.animate(0);
+    this.load().then(() => {
+      this.boot.log('Starting game loop...');
+      this.boot.done();
+      this.animate(0);
+    });
+  }
+
+  private async load() {
+    this.boot.log('Setting up ground and sky...');
+    this.setupEnvironment();
+
+    this.boot.log('Loading aircraft model...');
+    await this.loadAircraft();
+
+    this.boot.log('Aircraft ready.');
+  }
+
+  private setupEnvironment() {
+    const groundTexture = this.generateGroundTexture();
+    groundTexture.wrapS = groundTexture.wrapT = THREE.RepeatWrapping;
+    groundTexture.repeat.set(1000, 1000);
+    const ground = new THREE.Mesh(
+      new THREE.PlaneGeometry(100000, 100000),
+      new THREE.MeshStandardMaterial({ map: groundTexture })
+    );
+    ground.rotation.x = -Math.PI / 2;
+    this.scene.add(ground);
+
+    const skyTexture = this.generateSkyTexture();
+    this.scene.background = skyTexture;
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.6);
+    const dir = new THREE.DirectionalLight(0xffffff, 0.8);
+    dir.position.set(100, 100, 50);
+    this.scene.add(ambient);
+    this.scene.add(dir);
+  }
+
+  private generateGroundTexture() {
+    const size = 256;
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = size;
+    const ctx = canvas.getContext('2d')!;
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        const g = 80 + Math.random() * 80;
+        ctx.fillStyle = `rgb(${g * 0.3},${g},${g * 0.3})`;
+        ctx.fillRect(x, y, 1, 1);
+      }
+    }
+    return new THREE.CanvasTexture(canvas);
+  }
+
+  private generateSkyTexture() {
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 256;
+    const ctx = canvas.getContext('2d')!;
+    const grad = ctx.createLinearGradient(0, 0, 0, 256);
+    grad.addColorStop(0, '#87CEEB');
+    grad.addColorStop(1, '#FFFFFF');
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, 1, 256);
+    return new THREE.CanvasTexture(canvas);
+  }
+
+  private loadAircraft() {
+    return new Promise<void>((resolve, reject) => {
+      const loader = new GLTFLoader();
+      loader.load(
+        '/models/f-22_raptor_-_fighter_jet_-_free.glb',
+        (gltf) => {
+          this.aircraft = gltf.scene;
+          this.aircraft.scale.set(0.01, 0.01, 0.01);
+          this.aircraft.rotateY(Math.PI / 2);
+          this.scene.add(this.aircraft);
+          resolve();
+        },
+        undefined,
+        (err) => {
+          console.error('Failed to load aircraft model', err);
+          reject(err);
+        }
+      );
+    });
   }
 
   private animate(time: number) {


### PR DESCRIPTION
## Summary
- add full-screen loading overlay that blocks input until assets are ready
- generate textured ground and sky with lighting for a more 3D environment
- rotate aircraft model so chase camera follows from behind

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a709005230832887c896d1ffea660e