### PR TITLE
Refine chase camera placement behind aircraft

### DIFF
--- a/client/src/cam/chase.ts
+++ b/client/src/cam/chase.ts
@@ -5,8 +5,8 @@ export class ChaseCamera {
   private position = new THREE.Vector3();
   private velocity = new THREE.Vector3();
   private mouseOffset = new THREE.Vector2();
-  private readonly CAM_UP = 2;
-  private readonly CAM_BACK = 4;
+  private readonly CAM_UP = 0.5;
+  private readonly CAM_BACK = 2;
   private readonly LOOK_AHEAD = 10;
   private readonly SPRING_K = 25;
   private readonly DAMPING = 10;


### PR DESCRIPTION
## Summary
- Position chase camera closer to the aircraft and directly behind it

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a70b0455488328823821c90f3055b1