### PR TITLE
feat: cámara orientada al avión + remapeo de controles de vuelo

### DIFF
--- a/client/src/cam/chase.ts
+++ b/client/src/cam/chase.ts
@@ -1,29 +1,31 @@
 import * as THREE from 'three';
 
 export class ChaseCamera {
-  private camera: THREE.PerspectiveCamera;
+  private camera:      THREE.PerspectiveCamera;
   private camPos      = new THREE.Vector3();
   private camVel      = new THREE.Vector3();
   private mouseOff    = new THREE.Vector2();
   private isCockpit   = false;
   private initialized = false;
 
-  // Tercera persona: suficientemente lejos para ver el modelo completo
-  private readonly CAM_BACK    = 22;   // m detrás del avión
-  private readonly CAM_UP      = 7;    // m sobre el avión
-  private readonly LOOK_AHEAD  = 50;   // m adelante del avión para apuntar cámara
-  private readonly SPRING_K    = 6;    // rigidez del resorte (suelto para dar inercia)
-  private readonly DAMPING     = 4;    // amortiguación
+  // Offset LOCAL respecto al avión: X=centrado, Y=arriba, Z negativo=atrás en frame local.
+  // Se transforma con el quaternion del avión → la cámara banquea con él.
+  private readonly LOCAL_OFFSET   = new THREE.Vector3(0, 3.5, -12);
+  private readonly COCKPIT_OFFSET = new THREE.Vector3(0, 1.0, -4.5);
 
-  // Vista cabina: justo detrás del tablero
-  private readonly COCKPIT_OFFSET = new THREE.Vector3(0, 1.0, 4.5);
+  // Resorte críticamente amortiguado: DAMPING = 2 × √SPRING_K
+  // → respuesta rápida sin overshoot ni efecto "slingshot"
+  private readonly SPRING_K = 60;
+  private readonly DAMPING  = 15.5;   // 2 × √60 ≈ 15.49
 
   constructor(camera: THREE.PerspectiveCamera) {
     this.camera = camera;
   }
 
   toggleView() {
-    this.isCockpit = !this.isCockpit;
+    this.isCockpit   = !this.isCockpit;
+    this.initialized = false;   // re-snap al cambiar de vista
+    this.camVel.set(0, 0, 0);
   }
 
   update(
@@ -35,38 +37,29 @@ export class ChaseCamera {
     let desiredPos: THREE.Vector3;
     let lookTarget: THREE.Vector3;
 
-    // Dirección real de vuelo — independiente de la orientación visual del modelo
-    const vel = aircraft.velocity;
-    const fwdWorld = vel.length() > 5
-      ? vel.clone().normalize()
-      : new THREE.Vector3(0, 0, 1).applyQuaternion(aircraft.quaternion);
-
-    // UP siempre en world-space para la cámara de persecución.
-    // Si se usara el "up" local del avión, cuando el avión banquea la cámara
-    // quedaría de costado en lugar de arriba.
-    const WORLD_UP = new THREE.Vector3(0, 1, 0);
-
     if (this.isCockpit) {
-      // Cabina: usa el frame local del avión (estás dentro de la cabina)
-      const cockpitOffset = this.COCKPIT_OFFSET.clone().applyQuaternion(aircraft.quaternion);
-      desiredPos = aircraft.position.clone().add(cockpitOffset);
-      lookTarget = aircraft.position.clone().addScaledVector(fwdWorld, 50);
-      // En cabina la cámara sigue instantáneamente (sin resorte)
+      // ── Vista cabina ──────────────────────────────────────────────────────
+      const offset   = this.COCKPIT_OFFSET.clone().applyQuaternion(aircraft.quaternion);
+      desiredPos     = aircraft.position.clone().add(offset);
+      const fwdLocal = new THREE.Vector3(0, 0, 1).applyQuaternion(aircraft.quaternion);
+      lookTarget     = aircraft.position.clone().addScaledVector(fwdLocal, 50);
       this.camPos.copy(desiredPos);
       this.camVel.set(0, 0, 0);
+
     } else {
-      // Tercera persona: atrás en la dirección opuesta al vuelo, arriba en world-up
-      const backWorld = fwdWorld.clone().negate();
-      const offset = backWorld.clone().multiplyScalar(this.CAM_BACK)
-        .addScaledVector(WORLD_UP, this.CAM_UP);
-      desiredPos = aircraft.position.clone().add(offset);
-      lookTarget = aircraft.position.clone();
+      // ── Vista tercera persona ─────────────────────────────────────────────
+      // El offset LOCAL se rota con el quaternion → cámara banquea con el avión
+      const offset = this.LOCAL_OFFSET.clone().applyQuaternion(aircraft.quaternion);
+      desiredPos   = aircraft.position.clone().add(offset);
+      lookTarget   = aircraft.position.clone();
 
       if (!this.initialized) {
+        // Snap en el primer frame: sin efecto slingshot al arrancar
         this.camPos.copy(desiredPos);
         this.camVel.set(0, 0, 0);
         this.initialized = true;
       } else {
+        // Resorte críticamente amortiguado (DAMPING = 2√K → sin oscilaciones)
         const delta = desiredPos.clone().sub(this.camPos);
         const accel = delta.clone().multiplyScalar(this.SPRING_K)
           .sub(this.camVel.clone().multiplyScalar(this.DAMPING));
@@ -75,20 +68,23 @@ export class ChaseCamera {
       }
     }
 
-    // Ajuste por mouse (clic derecho): desplazar el punto de mira
+    // ── Mouse look (clic derecho) ─────────────────────────────────────────
     this.mouseOff.x = THREE.MathUtils.lerp(this.mouseOff.x, mouse.x, 5 * dt);
     this.mouseOff.y = THREE.MathUtils.lerp(this.mouseOff.y, mouse.y, 5 * dt);
-    if (!mouse.x && !mouse.y) {
-      this.mouseOff.lerp(new THREE.Vector2(), 3 * dt);
-    }
-    const rightWorld = fwdWorld.clone().cross(WORLD_UP).normalize();
-    lookTarget.addScaledVector(rightWorld, this.mouseOff.x * 30);
-    lookTarget.addScaledVector(WORLD_UP, -this.mouseOff.y * 20);
+    if (!mouse.x && !mouse.y) this.mouseOff.lerp(new THREE.Vector2(), 3 * dt);
 
-    // FOV dinámico: más ancho a mayor velocidad (sensación de aceleración)
+    const rightAircraft = new THREE.Vector3(1, 0, 0).applyQuaternion(aircraft.quaternion);
+    const upAircraft    = new THREE.Vector3(0, 1, 0).applyQuaternion(aircraft.quaternion);
+    lookTarget.addScaledVector(rightAircraft,  this.mouseOff.x * 30);
+    lookTarget.addScaledVector(upAircraft,    -this.mouseOff.y * 20);
+
+    // ── FOV dinámico (sensación de velocidad) ────────────────────────────
     const t = THREE.MathUtils.clamp((speed - 55) / (560 - 55), 0, 1);
-    const targetFov = THREE.MathUtils.lerp(65, 95, t);
-    this.camera.fov = THREE.MathUtils.lerp(this.camera.fov, targetFov, 4 * dt);
+    this.camera.fov = THREE.MathUtils.lerp(
+      this.camera.fov,
+      THREE.MathUtils.lerp(65, 95, t),
+      4 * dt
+    );
     this.camera.updateProjectionMatrix();
 
     this.camera.position.copy(this.camPos);

--- a/client/src/hud/hud.ts
+++ b/client/src/hud/hud.ts
@@ -81,8 +81,8 @@ export class HUD {
     });
     this.keyHints.innerText =
       'W/S   → cabeceo\n' +
-      'A/D   → guiñada\n' +
-      '←/→   → alabeo\n' +
+      'A/D   → alabeo\n' +
+      'Q/E   → guiñada\n' +
       'Shift/Ctrl → motor\n' +
       'V → cámara  P → avión\n' +
       'R → respawn  Esp → misil';

--- a/client/src/input/controls.ts
+++ b/client/src/input/controls.ts
@@ -60,21 +60,20 @@ export class Controls {
 
   update() {
     return {
-      // W/S → pitch (subir / bajar morro)
+      // W/S → cabeceo (nose up / nose down)
       pitch: (this.keys['KeyW'] ? 1 : 0) - (this.keys['KeyS'] ? 1 : 0),
-      // A/D → yaw (girar izquierda / derecha)
-      yaw: (this.keys['KeyA'] ? 1 : 0) - (this.keys['KeyD'] ? 1 : 0),
-      // Flechas izq/der → roll (inclinación lateral)
-      roll: (this.keys['ArrowRight'] ? 1 : 0) - (this.keys['ArrowLeft'] ? 1 : 0),
+      // A/D → alabeo (roll left / roll right)
+      roll:  (this.keys['KeyA'] ? 1 : 0) - (this.keys['KeyD'] ? 1 : 0),
+      // Q/E → guiñada (yaw left / yaw right)
+      yaw:   (this.keys['KeyQ'] ? 1 : 0) - (this.keys['KeyE'] ? 1 : 0),
       // Shift / Ctrl → throttle
       throttle: (this.keys['ShiftLeft'] || this.keys['ShiftRight'] ? 1 : 0) -
                 (this.keys['ControlLeft'] || this.keys['ControlRight'] ? 1 : 0),
-      fire: !!this.keys['Space'],
-      respawn: !!this.keys['KeyR'],
-      pause: !!this.keys['Escape'],
-      // P → cambiar avión, V → cambiar vista cámara
+      fire:        !!this.keys['Space'],
+      respawn:     !!this.keys['KeyR'],
+      pause:       !!this.keys['Escape'],
       planeToggle: !!this.keys['KeyP'],
-      viewToggle: !!this.keys['KeyV'],
+      viewToggle:  !!this.keys['KeyV'],
       mouseX: this.mouse.down ? this.mouse.x : 0,
       mouseY: this.mouse.down ? this.mouse.y : 0,
     };


### PR DESCRIPTION
cam/chase.ts — reescritura completa:
- Offset LOCAL (0, 3.5, -12) aplicado con quaternion del avión → la cámara banquea con el avión (roll/pitch/yaw)
- Resorte críticamente amortiguado (K=60, D=15.5 = 2√60) → seguimiento rápido sin oscilaciones ni efecto slingshot
- Snap instantáneo en el primer frame y al cambiar de vista
- FOV dinámico 65°-95° según velocidad mantenido

input/controls.ts — remapeo estándar de vuelo:
- W/S → cabeceo (pitch up/down)
- A/D → alabeo (roll left/right)
- Q/E → guiñada (yaw left/right)
- Shift/Ctrl → motor (sin cambio)

hud/hud.ts — leyenda de controles actualizada

https://claude.ai/code/session_01F3193Y6X3FaFXjTjCi9EbR